### PR TITLE
fix issue that await PublicClientApplication.logout() never returns

### DIFF
--- a/android/src/main/kotlin/uk/co/moodio/msal_flutter/MsalFlutterPlugin.kt
+++ b/android/src/main/kotlin/uk/co/moodio/msal_flutter/MsalFlutterPlugin.kt
@@ -65,7 +65,7 @@ class MsalFlutterPlugin: MethodCallHandler {
 
         //call signout
         if(call.method == "logout"){
-            logout()
+            logout(result)
             return
         }
 
@@ -133,10 +133,11 @@ class MsalFlutterPlugin: MethodCallHandler {
 
     }
 
-    private fun logout(){
-        for(account in msalApp.accounts)
-        {
-            msalApp.removeAccount(account)
+    private fun logout(result: Result){
+        while(msalApp.accounts.any()){
+            Log.d("MsalFlutter","Removing old account")
+            msalApp.removeAccount(msalApp.accounts.first())
         }
+        result.success(true)
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,6 +69,7 @@ class _MyAppState extends State<MyApp> {
     String res;
     try{
       await pca.logout();
+      res = "Account removed";
     } on MsalException {
       res = "Error signing out";
     }

--- a/ios/Classes/SwiftMsalFlutterPlugin.swift
+++ b/ios/Classes/SwiftMsalFlutterPlugin.swift
@@ -136,6 +136,7 @@ public class SwiftMsalFlutterPlugin: NSObject, FlutterPlugin {
         let cachedAccounts = try application.allAccounts()
 
         if cachedAccounts.isEmpty {
+          result(true)
           return
         }
 
@@ -146,6 +147,7 @@ public class SwiftMsalFlutterPlugin: NSObject, FlutterPlugin {
       catch {
         result(FlutterError(code: "CONFIG_ERROR", message: "Unable get remove accounts", details: nil))
       }
+      result(true)
     }
     else {
       result(FlutterError(code: "CONFIG_ERROR", message: "Unable to create MSALPublicClientApplication", details: nil))


### PR DESCRIPTION
@mswehli Thank you for your great work of this library first!

I use it in my project and found an issue that  when await PublicClientApplication.logout() it never returns. I finally believe it came from native code of MethodChannel handler which doesn't set the method result properly. I fix it on both Android and iOS platforms and create this PR.

Please have a review. Happy to any further discussion.
